### PR TITLE
reformat target in Makefile was missing in the list of PHONY targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ reformat:
                --align-pointer=name \
                *.[ch]
 
-.PHONY: clean
+.PHONY: clean reformat


### PR DESCRIPTION
The reformat target in the Makefile for this project is also a PHONY targets together with the clean target.
