### PR TITLE
fix the iter bug of losing the first element

### DIFF
--- a/hashset_itr.c
+++ b/hashset_itr.c
@@ -30,10 +30,6 @@ hashset_itr_t hashset_iterator(hashset_t set)
   itr->set = set;
   itr->index = 0;
 
-  /* advance to the first item if one is present */
-  if (set->nitems > 0)
-    hashset_iterator_next(itr);
-
   return itr;
 }
 

--- a/hashset_itr.c
+++ b/hashset_itr.c
@@ -42,12 +42,12 @@ int hashset_iterator_has_next(hashset_itr_t itr)
   size_t index;
 
   /* empty or end of the set */
-  if (itr->set->nitems == 0 || itr->index == itr->set->capacity - 1)
+  if (itr->set->nitems == 0 || itr->index == itr->set->capacity)
     return 0;
 
   /* peek to find another entry */
   index = itr->index;
-  while(index <= itr->set->capacity -1)
+  while(index < itr->set->capacity)
   {
     size_t value = itr->set->items[index++];
     if(value != 0)

--- a/hashset_itr.c
+++ b/hashset_itr.c
@@ -49,7 +49,7 @@ int hashset_iterator_has_next(hashset_itr_t itr)
   index = itr->index;
   while(index <= itr->set->capacity -1)
   {
-    size_t value = itr->set->items[index];
+    size_t value = itr->set->items[index++];
     if(value != 0)
       return 1;
   }


### PR DESCRIPTION
Do not skip the first non-zero item when creating the iterator.